### PR TITLE
[bugFix] add exit condition in main loop

### DIFF
--- a/EmployeeManagement/EmployeeManagement/main.cpp
+++ b/EmployeeManagement/EmployeeManagement/main.cpp
@@ -35,7 +35,9 @@ public:
 		Parser parser;
 		CommandFactory commandFactory;
 		while (fileIn_->hasMore()) {
-			Input input = parser.parseLine(fileIn_->readLine());
+			string line = fileIn_->readLine();
+			if (line == "") break;
+			Input input = parser.parseLine(line);
 			bool doPrintDetail = input.getFirstOption() == "-p";
 			logger_->setPrintDetail(doPrintDetail);
 			shared_ptr<ICommand> cmd = commandFactory.createCommand(input);


### PR DESCRIPTION
readLine()의 결과가 ""이면 loop를 빠져다가도록 수정하였습니다.

Signed-off-by: Sungju Huh <sjslush@gmail.com>